### PR TITLE
Add 'perPage' params at getCollections helper

### DIFF
--- a/nodes/PocketBase/LoadOptions.ts
+++ b/nodes/PocketBase/LoadOptions.ts
@@ -45,6 +45,7 @@ export const LoadOptions = {
 		const { items } = await this.helpers.httpRequestWithAuthentication.call(this, 'pocketBaseApi', {
 			url: `${url}/api/collections`,
 			method: 'GET',
+			qs: { perPage: 500 },
 		});
 
 		items.forEach(({ name }: { name: string }) => {


### PR DESCRIPTION
The current implementations is tied to default of 30 wich does not loads all collections for a large database.