### PR TITLE
fix(workflow): ensure package-lock.json is updated in nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -43,9 +43,11 @@ jobs:
             echo "updates_found=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Update package-lock.json
+      - name: Update files
         if: steps.check_updates.outputs.updates_found == 'true'
-        run: npm install
+        run: |
+          npm run version:update
+          npm install
 
       - name: Run pipeline
         if: steps.check_updates.outputs.updates_found == 'true'
@@ -57,7 +59,7 @@ jobs:
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}
-          commit-message: "chore: update compatibility versions in README.md"
+          commit-message: "chore: nightly compatibility updates"
           title: "Nightly Compatibility Updates"
           body: "Automated nightly updates for compatibility versions."
           branch: nightly-updates


### PR DESCRIPTION
This PR fixes the nightly workflow by ensuring that `package-lock.json` is updated after the versions in `package.json` are bumped. Previously, `npm install` was running before the update script, resulting in a stale lockfile in the generated PRs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the nightly compatibility update process to execute version updates before reinstalling dependencies, with improved commit messaging for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->