### PR TITLE
fix: authenticate via preSend hook instead of expirable JWT credential

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ yarn.lock
 .idea
 .tool-versions
 .junie
+custom-nodes

--- a/credentials/PocketbaseHttpApi.credentials.ts
+++ b/credentials/PocketbaseHttpApi.credentials.ts
@@ -1,10 +1,7 @@
 import {
-  IAuthenticate,
   IconFile,
-  ICredentialDataDecryptedObject,
   ICredentialTestRequest,
   ICredentialType,
-  IHttpRequestHelper,
   INodeProperties,
 } from "n8n-workflow";
 
@@ -37,15 +34,6 @@ export class PocketbaseHttpApi implements ICredentialType {
       default: "",
       required: true,
     },
-    {
-      displayName: "JWT Token",
-      name: "jwtToken",
-      type: "hidden",
-      typeOptions: {
-        expirable: true,
-      },
-      default: "",
-    },
   ];
 
   test: ICredentialTestRequest = {
@@ -74,30 +62,6 @@ export class PocketbaseHttpApi implements ICredentialType {
         },
       },
     ],
-  };
-
-  async preAuthentication(this: IHttpRequestHelper, credentials: ICredentialDataDecryptedObject) {
-    const url = (credentials.url as string).replace(/\/$/, "");
-
-    const { token } = (await this.helpers.httpRequest({
-      method: "POST",
-      url: `${url}/api/collections/_superusers/auth-with-password`,
-      body: {
-        identity: credentials.username,
-        password: credentials.password,
-      },
-    })) as { token: string };
-
-    return { jwtToken: token };
-  }
-
-  authenticate: IAuthenticate = {
-    type: "generic",
-    properties: {
-      headers: {
-        Authorization: "={{ $credentials.jwtToken }}",
-      },
-    },
   };
 
   icon = "file:pocketbase.svg" as IconFile;

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -20,9 +20,13 @@ services:
       - N8N_TASK_BROKER_PORT=5680
     volumes:
       - .:/home/node/custom-nodes
+      - n8n_data:/home/node/.n8n
     # We would need to tell n8n to load the custom node from the volume
     # Usually this is done by installing it in ~/.n8n/nodes
     # For a test run, we can use an entrypoint script to symlink or install
     entrypoint: /bin/sh -c "mkdir -p /home/node/.n8n/nodes/node_modules && ln -sf /home/node/custom-nodes /home/node/.n8n/nodes/node_modules/n8n-nodes-pocketbase && n8n"
     depends_on:
       - pocketbase
+
+volumes:
+  n8n_data:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -24,7 +24,7 @@ services:
     # We would need to tell n8n to load the custom node from the volume
     # Usually this is done by installing it in ~/.n8n/nodes
     # For a test run, we can use an entrypoint script to symlink or install
-    entrypoint: /bin/sh -c "mkdir -p /home/node/.n8n/nodes/node_modules && ln -sf /home/node/custom-nodes /home/node/.n8n/nodes/node_modules/n8n-nodes-pocketbase && n8n"
+    entrypoint: /bin/sh -c "mkdir -p /home/node/.n8n/nodes/node_modules && rm -f /home/node/.n8n/nodes/node_modules/n8n-nodes-pocketbase && ln -sf /home/node/custom-nodes /home/node/.n8n/nodes/node_modules/n8n-nodes-pocketbase && n8n"
     depends_on:
       - pocketbase
 

--- a/nodes/Common/GenericFunctions.ts
+++ b/nodes/Common/GenericFunctions.ts
@@ -8,6 +8,64 @@ import {
 } from "n8n-workflow";
 import { prepareRequestBody } from "./RequestBodyFunctions";
 
+interface TokenCacheEntry {
+  token: string;
+  expiresAtMs: number;
+}
+
+const tokenCache = new Map<string, TokenCacheEntry>();
+
+function parseJwtExpiry(jwtToken: string): number {
+  try {
+    const [, payload] = jwtToken.split(".");
+    const padded = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const decoded = JSON.parse(Buffer.from(padded, "base64").toString("utf8"));
+    return typeof decoded.exp === "number" ? decoded.exp * 1000 : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export function _resetTokenCacheForTesting(): void {
+  tokenCache.clear();
+}
+
+export async function fetchPocketbaseToken(
+  httpRequest: (options: IHttpRequestOptions) => Promise<unknown>,
+  url: string,
+  username: string,
+  password: string,
+): Promise<string> {
+  const cacheKey = `${url}::${username}`;
+  const cached = tokenCache.get(cacheKey);
+  if (cached && Date.now() < cached.expiresAtMs - 60_000) {
+    return cached.token;
+  }
+  const { token } = (await httpRequest({
+    method: "POST",
+    url: `${url}/api/collections/_superusers/auth-with-password`,
+    body: { identity: username, password },
+  })) as { token: string };
+  tokenCache.set(cacheKey, { token, expiresAtMs: parseJwtExpiry(token) });
+  return token;
+}
+
+export async function authenticatePreSend(
+  this: IExecuteSingleFunctions,
+  requestOptions: IHttpRequestOptions,
+): Promise<IHttpRequestOptions> {
+  const credentials = await this.getCredentials("pocketbaseHttpApi");
+  const url = (credentials.url as string).replace(/\/$/, "");
+  const token = await fetchPocketbaseToken(
+    (opts) => this.helpers.httpRequest(opts),
+    url,
+    credentials.username as string,
+    credentials.password as string,
+  );
+  requestOptions.headers = { ...requestOptions.headers, Authorization: token };
+  return requestOptions;
+}
+
 export async function recordViewPreSendAction(
   this: IExecuteSingleFunctions,
   requestOptions: IHttpRequestOptions,

--- a/nodes/Common/LoadOptions.ts
+++ b/nodes/Common/LoadOptions.ts
@@ -1,4 +1,5 @@
 import type { IDataObject, ILoadOptionsFunctions, INodePropertyOptions } from "n8n-workflow";
+import { fetchPocketbaseToken } from "./GenericFunctions";
 
 export interface PocketBaseField {
   autogeneratePattern?: string;
@@ -26,21 +27,24 @@ async function loadPocketBaseFields(
   this: ILoadOptionsFunctions,
   collectionName: string | null = null,
 ): Promise<PocketBaseField[]> {
-  const { url } = await this.getCredentials("pocketbaseHttpApi");
-  const normalizedUrl = (url as string).replace(/\/$/, "");
+  const credentials = await this.getCredentials("pocketbaseHttpApi");
+  const normalizedUrl = (credentials.url as string).replace(/\/$/, "");
   const resource = collectionName
     ? collectionName
     : (this.getNodeParameter("resource") as unknown as string);
-  const { fields } = await this.helpers.httpRequestWithAuthentication.call(
-    this,
-    "pocketbaseHttpApi",
-    {
-      url: `${normalizedUrl}/api/collections/${resource}`,
-      method: "GET",
-    },
+  const token = await fetchPocketbaseToken(
+    (opts) => this.helpers.httpRequest(opts),
+    normalizedUrl,
+    credentials.username as string,
+    credentials.password as string,
   );
+  const { fields } = (await this.helpers.httpRequest({
+    url: `${normalizedUrl}/api/collections/${resource}`,
+    method: "GET",
+    headers: { Authorization: token },
+  })) as { fields: PocketBaseField[] };
 
-  return fields as PocketBaseField[];
+  return fields;
 }
 
 /**
@@ -67,20 +71,26 @@ function getRecordLabel(id: string, data: IDataObject): string {
 
 export const LoadOptions = {
   async getCollections(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
-    const { url } = await this.getCredentials("pocketbaseHttpApi");
-    const normalizedUrl = (url as string).replace(/\/$/, "");
+    const credentials = await this.getCredentials("pocketbaseHttpApi");
+    const normalizedUrl = (credentials.url as string).replace(/\/$/, "");
+    const token = await fetchPocketbaseToken(
+      (opts) => this.helpers.httpRequest(opts),
+      normalizedUrl,
+      credentials.username as string,
+      credentials.password as string,
+    );
 
     const items: { name: string }[] = [];
     let page: number = 1;
     let totalPages: number = 0;
 
     do {
-      const { items: pageItems, totalPages: pageTotalPages } =
-        await this.helpers.httpRequestWithAuthentication.call(this, "pocketbaseHttpApi", {
-          url: `${normalizedUrl}/api/collections`,
-          method: "GET",
-          qs: { page },
-        });
+      const { items: pageItems, totalPages: pageTotalPages } = (await this.helpers.httpRequest({
+        url: `${normalizedUrl}/api/collections`,
+        method: "GET",
+        qs: { page },
+        headers: { Authorization: token },
+      })) as { items: { name: string }[]; totalPages: number };
 
       items.push(...pageItems);
       totalPages = pageTotalPages;
@@ -133,9 +143,15 @@ export const LoadOptions = {
   },
   async getRows(this: ILoadOptionsFunctions): Promise<INodePropertyOptions[]> {
     const returnData: INodePropertyOptions[] = [];
-    const { url } = await this.getCredentials("pocketbaseHttpApi");
-    const normalizedUrl = (url as string).replace(/\/$/, "");
+    const credentials = await this.getCredentials("pocketbaseHttpApi");
+    const normalizedUrl = (credentials.url as string).replace(/\/$/, "");
     const resource = this.getNodeParameter("resource") as unknown as string;
+    const token = await fetchPocketbaseToken(
+      (opts) => this.helpers.httpRequest(opts),
+      normalizedUrl,
+      credentials.username as string,
+      credentials.password as string,
+    );
 
     const items: IDataObject[] = [];
     let page: number = 1;
@@ -143,14 +159,14 @@ export const LoadOptions = {
     const maxPages = 5; // Load up to 5 pages for the dropdown
 
     do {
-      const { items: pageItems, totalPages: pageTotalPages } =
-        await this.helpers.httpRequestWithAuthentication.call(this, "pocketbaseHttpApi", {
-          url: `${normalizedUrl}/api/collections/${resource}/records`,
-          method: "GET",
-          qs: { sort: "-created", page, perPage: 50 },
-        });
+      const { items: pageItems, totalPages: pageTotalPages } = (await this.helpers.httpRequest({
+        url: `${normalizedUrl}/api/collections/${resource}/records`,
+        method: "GET",
+        qs: { sort: "-created", page, perPage: 50 },
+        headers: { Authorization: token },
+      })) as { items: IDataObject[]; totalPages: number };
 
-      items.push(...(pageItems as IDataObject[]));
+      items.push(...pageItems);
       totalPages = pageTotalPages;
       page++;
     } while (page <= totalPages && page <= maxPages);

--- a/nodes/PocketbaseHttp/PocketbaseHttp.node.ts
+++ b/nodes/PocketbaseHttp/PocketbaseHttp.node.ts
@@ -1,5 +1,6 @@
 import { NodeConnectionTypes, type INodeType, type INodeTypeDescription } from "n8n-workflow";
 import {
+  authenticatePreSend,
   pagination,
   recordCreatePreSendAction,
   recordUpdatePreSendAction,
@@ -68,7 +69,7 @@ export class PocketbaseHttp implements INodeType {
                 postReceive: [recordViewPostReceiveAction],
               },
               send: {
-                preSend: [recordViewPreSendAction],
+                preSend: [authenticatePreSend, recordViewPreSendAction],
                 paginate: true,
               },
               operations: { pagination },
@@ -84,7 +85,7 @@ export class PocketbaseHttp implements INodeType {
                 url: `=/api/collections/{{$parameter["resource"]}}/records/{{$parameter["elementId"]}}`,
               },
               send: {
-                preSend: [recordViewPreSendAction],
+                preSend: [authenticatePreSend, recordViewPreSendAction],
               },
             },
           },
@@ -98,7 +99,7 @@ export class PocketbaseHttp implements INodeType {
                 url: `=/api/collections/{{$parameter["resource"]}}/records`,
               },
               send: {
-                preSend: [recordCreatePreSendAction],
+                preSend: [authenticatePreSend, recordCreatePreSendAction],
               },
             },
           },
@@ -112,7 +113,7 @@ export class PocketbaseHttp implements INodeType {
                 url: `=/api/collections/{{$parameter["resource"]}}/records/{{$parameter["elementId"]}}`,
               },
               send: {
-                preSend: [recordUpdatePreSendAction],
+                preSend: [authenticatePreSend, recordUpdatePreSendAction],
               },
             },
           },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "2.3.0",
       "license": "MIT",
       "dependencies": {
-        "eventsource": "^4.1.0"
+        "eventsource": "^4.1.0",
+        "form-data": "^4.0.5"
       },
       "devDependencies": {
         "@n8n/node-cli": "^0.29.0",
@@ -5516,8 +5517,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
@@ -5546,24 +5546,6 @@
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
-      }
-    },
-    "node_modules/axios/node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/axios/node_modules/proxy-from-env": {
@@ -5728,7 +5710,6 @@
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "function-bind": "^1.1.2"
@@ -5985,7 +5966,6 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -6390,7 +6370,6 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -6473,7 +6452,6 @@
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
         "es-errors": "^1.3.0",
@@ -6517,7 +6495,6 @@
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6527,7 +6504,6 @@
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -6542,7 +6518,6 @@
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
       },
@@ -6555,7 +6530,6 @@
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -7345,11 +7319,10 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -7413,7 +7386,6 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7454,7 +7426,6 @@
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
@@ -7487,7 +7458,6 @@
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
         "es-object-atoms": "^1.0.0"
@@ -7641,7 +7611,6 @@
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7703,7 +7672,6 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -7716,7 +7684,6 @@
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -7732,7 +7699,6 @@
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
       "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -7876,6 +7842,24 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/ibm-cloud-sdk-core/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/ibm-cloud-sdk-core/node_modules/ms": {
@@ -9138,7 +9122,6 @@
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -9193,7 +9176,6 @@
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -9203,7 +9185,6 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -9306,6 +9287,23 @@
       },
       "peerDependencies": {
         "zod": "3.25.67"
+      }
+    },
+    "node_modules/n8n-workflow/node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/nanoid": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "prepublishOnly": "n8n-node prerelease"
   },
   "dependencies": {
-    "eventsource": "^4.1.0"
+    "eventsource": "^4.1.0",
+    "form-data": "^4.0.5"
   },
   "devDependencies": {
     "@n8n/node-cli": "^0.29.0",

--- a/scripts/full-test.sh
+++ b/scripts/full-test.sh
@@ -96,6 +96,7 @@ echo "Running Integration Workflow (process 1)..."
 docker compose -f docker-compose.test.yml run --rm \
   --entrypoint /bin/sh n8n -c "
     mkdir -p /home/node/.n8n/nodes/node_modules && \
+    rm -f \"/home/node/.n8n/nodes/node_modules/$PACKAGE_NAME\" && \
     ln -sf /home/node/custom-nodes \"/home/node/.n8n/nodes/node_modules/$PACKAGE_NAME\" && \
     n8n import:credentials --input=/home/node/custom-nodes/tests/workflows/integration_credentials.json && \
     n8n import:credentials --input=/home/node/custom-nodes/tests/workflows/integration_credentials_expired.json && \
@@ -146,6 +147,7 @@ set +e
 docker compose -f docker-compose.test.yml run --rm \
   --entrypoint /bin/sh n8n -c "
     mkdir -p /home/node/.n8n/nodes/node_modules && \
+    rm -f \"/home/node/.n8n/nodes/node_modules/$PACKAGE_NAME\" && \
     ln -sf /home/node/custom-nodes \"/home/node/.n8n/nodes/node_modules/$PACKAGE_NAME\" && \
     n8n execute --id=2
 " > expired_token_output.txt 2>&1

--- a/scripts/full-test.sh
+++ b/scripts/full-test.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 set -e
 
+# Load fnm so that `node` and `npm` are on PATH (non-interactive bash skips .bashrc)
+if command -v fnm &>/dev/null; then
+    eval "$(fnm env --shell bash)"
+fi
+
 # EXIT trap for teardown
 on_exit() {
 	EXIT_CODE=$?
@@ -11,20 +16,25 @@ on_exit() {
 			cat workflow_output.txt
 			echo "--------------------------------"
 		fi
+		if [ -f expired_token_output.txt ]; then
+			echo "--- Expired Token Test Output ---"
+			cat expired_token_output.txt
+			echo "--------------------------------"
+		fi
 		echo "--- PocketBase Logs ---"
 		docker compose -f docker-compose.test.yml logs pocketbase
 		echo "-----------------------"
 	fi
 	echo "Cleaning up..."
-	docker compose -f docker-compose.test.yml down
-	rm -f workflow_output.txt
+	docker compose -f docker-compose.test.yml down -v
+	rm -f workflow_output.txt expired_token_output.txt
 	exit $EXIT_CODE
 }
 trap on_exit EXIT
 
-# Sync versions and package name
+# Sync versions and package name (non-fatal: may fail locally due to GitHub API rate limits)
 echo "Synchronizing versions and package name..."
-npm run version:update
+npm run version:update || echo "⚠️  Version sync skipped (GitHub API rate limit or network issue)"
 
 # Get package name from package.json
 PACKAGE_NAME=$(node -p "require('./package.json').name")
@@ -65,19 +75,36 @@ wait_for_service "n8n" "http://localhost:5678/healthz"
 echo "Setting up PocketBase superuser..."
 docker compose -f docker-compose.test.yml exec -T pocketbase /usr/local/bin/pocketbase --dir=/pb_data superuser upsert test@example.com password123
 
-# Execution: Stop main n8n to avoid port conflicts and run the test via CLI
-echo "Running Integration Workflow..."
+# Restrict the users collection list rule to superusers-only, matching the
+# production scenario where collections require valid superuser authentication.
+echo "Restricting users collection list rule..."
+ADMIN_TOKEN=$(curl -sf -X POST "http://localhost:8090/api/collections/_superusers/auth-with-password" \
+  -H "Content-Type: application/json" \
+  -d '{"identity":"test@example.com","password":"password123"}' \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['token'])")
+curl -sf -X PATCH "http://localhost:8090/api/collections/users" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: ${ADMIN_TOKEN}" \
+  -d '{"listRule": null}' > /dev/null
+echo "✓ Users list rule set to superusers-only"
+
+# Stop n8n to avoid port conflicts with docker compose run
 docker compose -f docker-compose.test.yml stop n8n
+
+# Process 1: import credentials + workflows, run the main CRUD test
+echo "Running Integration Workflow (process 1)..."
 docker compose -f docker-compose.test.yml run --rm \
   --entrypoint /bin/sh n8n -c "
     mkdir -p /home/node/.n8n/nodes/node_modules && \
     ln -sf /home/node/custom-nodes \"/home/node/.n8n/nodes/node_modules/$PACKAGE_NAME\" && \
     n8n import:credentials --input=/home/node/custom-nodes/tests/workflows/integration_credentials.json && \
+    n8n import:credentials --input=/home/node/custom-nodes/tests/workflows/integration_credentials_expired.json && \
     n8n import:workflow --input=/home/node/custom-nodes/tests/workflows/integration_test.json && \
+    n8n import:workflow --input=/home/node/custom-nodes/tests/workflows/integration_expired_token_test.json && \
     n8n execute --id=1
 " > workflow_output.txt 2>&1
 
-# Verify via logs (enabled by --dev flag in pocketbase)
+# Verify main workflow via PocketBase logs
 echo "Verifying results in PocketBase logs..."
 PB_LOGS=$(docker compose -f docker-compose.test.yml logs pocketbase)
 
@@ -110,6 +137,33 @@ else
   tail -n 20 workflow_output.txt
   exit 1
 fi
+
+# Process 2: completely fresh n8n process — no shared memory, DB persisted via volume.
+# This simulates a scheduled execution that starts cold with an expired stored token.
+echo ""
+echo "--- Expired Token Refresh Test (process 2, isolated) ---"
+set +e
+docker compose -f docker-compose.test.yml run --rm \
+  --entrypoint /bin/sh n8n -c "
+    mkdir -p /home/node/.n8n/nodes/node_modules && \
+    ln -sf /home/node/custom-nodes \"/home/node/.n8n/nodes/node_modules/$PACKAGE_NAME\" && \
+    n8n execute --id=2
+" > expired_token_output.txt 2>&1
+EXPIRED_EXIT=$?
+set -e
+
+if [ $EXPIRED_EXIT -eq 0 ] && grep -q '"status": *"success"' expired_token_output.txt 2>/dev/null; then
+  echo "✅ Workflow with expired token SUCCEEDED in isolated process"
+  echo "   Token was refreshed via preSend without any shared in-memory state"
+else
+  echo "❌ Workflow with expired token FAILED in isolated process"
+  echo ""
+  echo "   n8n output (last 20 lines, excluding sourcemap noise):"
+  grep -v "Sourcemap" expired_token_output.txt | tail -20 | sed 's/^/   /'
+  echo "--------------------------------------------------------"
+  exit 1
+fi
+echo "--------------------------------------------------------"
 
 # Run unit and integration tests
 export RUN_POCKETBASE_INTEGRATION="true"

--- a/tests/PocketbaseCredentials.spec.ts
+++ b/tests/PocketbaseCredentials.spec.ts
@@ -1,63 +1,75 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { PocketbaseHttpApi } from "../credentials/PocketbaseHttpApi.credentials";
-import type { IHttpRequestHelper, ICredentialDataDecryptedObject } from "n8n-workflow";
+import type { IHttpRequestOptions } from "n8n-workflow";
+import { fetchPocketbaseToken, _resetTokenCacheForTesting } from "../nodes/Common/GenericFunctions";
 
-describe("PocketbaseHttpApi Credentials", () => {
-  let credentialsType: PocketbaseHttpApi;
-  let mockHttpRequestHelper: any;
+function buildJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64");
+  return `${header}.${body}.fakesig`;
+}
+
+describe("fetchPocketbaseToken", () => {
+  let mockHttpRequest: ReturnType<typeof vi.fn<(options: IHttpRequestOptions) => Promise<unknown>>>;
 
   beforeEach(() => {
-    credentialsType = new PocketbaseHttpApi();
-    mockHttpRequestHelper = {
-      helpers: {
-        httpRequest: vi.fn(),
-      },
-    };
-  });
-
-  it("should perform login in preAuthentication", async () => {
-    const credentials = {
-      url: "http://localhost:8090",
-      username: "admin@example.com",
-      password: "password123",
-    } as unknown as ICredentialDataDecryptedObject;
-
-    mockHttpRequestHelper.helpers.httpRequest.mockResolvedValue({ token: "mock-jwt-token" });
-
-    const result = await credentialsType.preAuthentication.call(
-      mockHttpRequestHelper as unknown as IHttpRequestHelper,
-      credentials,
-    );
-
-    expect(result).toEqual({ jwtToken: "mock-jwt-token" });
-    expect(mockHttpRequestHelper.helpers.httpRequest).toHaveBeenCalledWith({
-      method: "POST",
-      url: "http://localhost:8090/api/collections/_superusers/auth-with-password",
-      body: {
-        identity: "admin@example.com",
-        password: "password123",
-      },
+    _resetTokenCacheForTesting();
+    mockHttpRequest = vi.fn<(options: IHttpRequestOptions) => Promise<unknown>>().mockResolvedValue({
+      token: "mock-jwt-token",
     });
   });
 
-  it("should handle trailing slash in URL", async () => {
-    const credentials = {
-      url: "http://localhost:8090/",
-      username: "admin@example.com",
-      password: "password123",
-    } as unknown as ICredentialDataDecryptedObject;
-
-    mockHttpRequestHelper.helpers.httpRequest.mockResolvedValue({ token: "mock-jwt-token" });
-
-    await credentialsType.preAuthentication.call(
-      mockHttpRequestHelper as unknown as IHttpRequestHelper,
-      credentials,
+  it("fetches a token and calls the auth endpoint", async () => {
+    const token = await fetchPocketbaseToken(
+      mockHttpRequest,
+      "http://localhost:8090",
+      "admin@example.com",
+      "password123",
     );
 
-    expect(mockHttpRequestHelper.helpers.httpRequest).toHaveBeenCalledWith(
-      expect.objectContaining({
-        url: "http://localhost:8090/api/collections/_superusers/auth-with-password",
-      }),
-    );
+    expect(token).toBe("mock-jwt-token");
+    expect(mockHttpRequest).toHaveBeenCalledOnce();
+    expect(mockHttpRequest).toHaveBeenCalledWith({
+      method: "POST",
+      url: "http://localhost:8090/api/collections/_superusers/auth-with-password",
+      body: { identity: "admin@example.com", password: "password123" },
+    });
+  });
+
+  it("reuses cached token when it is not expired", async () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 3600;
+    const freshToken = buildJwt({ exp: futureExp });
+    mockHttpRequest.mockResolvedValue({ token: freshToken });
+
+    await fetchPocketbaseToken(mockHttpRequest, "http://cache-hit.local", "admin", "pass");
+    const second = await fetchPocketbaseToken(mockHttpRequest, "http://cache-hit.local", "admin", "pass");
+
+    expect(second).toBe(freshToken);
+    expect(mockHttpRequest).toHaveBeenCalledOnce();
+  });
+
+  it("re-fetches when cached token is within 60 s of expiry", async () => {
+    const nearExp = Math.floor(Date.now() / 1000) + 30;
+    const soonToken = buildJwt({ exp: nearExp });
+    mockHttpRequest.mockResolvedValueOnce({ token: soonToken });
+    mockHttpRequest.mockResolvedValueOnce({ token: "refreshed-token" });
+
+    await fetchPocketbaseToken(mockHttpRequest, "http://near-expiry.local", "admin", "pass");
+    const second = await fetchPocketbaseToken(mockHttpRequest, "http://near-expiry.local", "admin", "pass");
+
+    expect(second).toBe("refreshed-token");
+    expect(mockHttpRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-fetches when cached token is already expired", async () => {
+    const pastExp = Math.floor(Date.now() / 1000) - 3600;
+    const staleToken = buildJwt({ exp: pastExp });
+    mockHttpRequest.mockResolvedValueOnce({ token: staleToken });
+    mockHttpRequest.mockResolvedValueOnce({ token: "fresh-token" });
+
+    await fetchPocketbaseToken(mockHttpRequest, "http://expired.local", "admin", "pass");
+    const second = await fetchPocketbaseToken(mockHttpRequest, "http://expired.local", "admin", "pass");
+
+    expect(second).toBe("fresh-token");
+    expect(mockHttpRequest).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/PocketbaseCredentials.spec.ts
+++ b/tests/PocketbaseCredentials.spec.ts
@@ -19,6 +19,10 @@ describe("fetchPocketbaseToken", () => {
   });
 
   it("fetches a token and calls the auth endpoint", async () => {
+    const futureExp = Math.floor(Date.now() / 1000) + 3600;
+    const expectedToken = buildJwt({ exp: futureExp });
+    mockHttpRequest.mockResolvedValue({ token: expectedToken });
+
     const token = await fetchPocketbaseToken(
       mockHttpRequest,
       "http://localhost:8090",
@@ -26,7 +30,7 @@ describe("fetchPocketbaseToken", () => {
       "password123",
     );
 
-    expect(token).toBe("mock-jwt-token");
+    expect(token).toBe(expectedToken);
     expect(mockHttpRequest).toHaveBeenCalledOnce();
     expect(mockHttpRequest).toHaveBeenCalledWith({
       method: "POST",
@@ -70,6 +74,25 @@ describe("fetchPocketbaseToken", () => {
     const second = await fetchPocketbaseToken(mockHttpRequest, "http://expired.local", "admin", "pass");
 
     expect(second).toBe("fresh-token");
+    expect(mockHttpRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it("propagates HTTP errors from the auth endpoint", async () => {
+    const networkError = new Error("connect ECONNREFUSED");
+    mockHttpRequest.mockRejectedValue(networkError);
+
+    await expect(
+      fetchPocketbaseToken(mockHttpRequest, "http://unreachable.local", "admin", "pass"),
+    ).rejects.toThrow("connect ECONNREFUSED");
+  });
+
+  it("re-fetches every call when the token has no exp claim", async () => {
+    const noExpToken = buildJwt({});
+    mockHttpRequest.mockResolvedValue({ token: noExpToken });
+
+    await fetchPocketbaseToken(mockHttpRequest, "http://no-exp.local", "admin", "pass");
+    await fetchPocketbaseToken(mockHttpRequest, "http://no-exp.local", "admin", "pass");
+
     expect(mockHttpRequest).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/RequestBodyFunctions.spec.ts
+++ b/tests/RequestBodyFunctions.spec.ts
@@ -230,7 +230,7 @@ describe("RequestBodyFunctions", () => {
         expect(appendSpy).toHaveBeenCalledWith("validObject", '{"foo":"bar"}');
         expect(appendSpy).toHaveBeenCalledWith("nullValue", "null");
 
-        const appendedKeys = appendSpy.mock.calls.map((call) => call[0]);
+        const appendedKeys = appendSpy.mock.calls.map((call: unknown[]) => call[0]);
         expect(appendedKeys).not.toContain("");
         expect(appendedKeys).not.toContain("  ");
         expect(appendedKeys).not.toContain(123);

--- a/tests/workflows/integration_credentials_expired.json
+++ b/tests/workflows/integration_credentials_expired.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "pocketbase-cred-id-expired",
+    "name": "Pocketbase Integration Test Credential - Expired Token",
+    "type": "pocketbaseHttpApi",
+    "data": {
+      "url": "http://pocketbase:8090",
+      "username": "test@example.com",
+      "password": "password123"
+    }
+  }
+]

--- a/tests/workflows/integration_expired_token_test.json
+++ b/tests/workflows/integration_expired_token_test.json
@@ -1,0 +1,43 @@
+{
+  "id": "2",
+  "name": "Pocketbase Expired Token Test Workflow",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "1",
+      "name": "When clicking 'Test workflow'",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [100, 100]
+    },
+    {
+      "parameters": {
+        "resource": "users",
+        "operation": "search"
+      },
+      "id": "2",
+      "name": "Pocketbase Search with Expired Token",
+      "type": "n8n-nodes-pocketbase.pocketbaseHttp",
+      "typeVersion": 1,
+      "position": [300, 100],
+      "credentials": {
+        "pocketbaseHttpApi": {
+          "id": "pocketbase-cred-id-expired"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "When clicking 'Test workflow'": {
+      "main": [
+        [
+          {
+            "node": "Pocketbase Search with Expired Token",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  }
+}


### PR DESCRIPTION
n8n's preAuthentication callback is not reliably called during scheduled
workflow execution — only when testing credentials manually. This caused
workflows to fail with 403 once the stored JWT expired, requiring a manual
credential re-test to recover.

Replace the expirable jwtToken / preAuthentication / authenticate approach
with an authenticatePreSend hook that runs unconditionally on every request.
It calls PocketBase's auth endpoint using the stored username and password,
with a module-level cache keyed by URL+username that respects token expiry
to avoid redundant re-auth on paginated requests.

LoadOptions is updated to use the same fetchPocketbaseToken helper directly
instead of relying on httpRequestWithAuthentication (which depended on the
now-removed authenticate property).

An isolated e2e test is added that reproduces the original bug: a fresh n8n
process with no in-memory token cache runs a workflow against a collection
restricted to superusers. The test passes with the fix in place and would
fail without it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simplified PocketBase credential entry (url, username, password) with automatic token-based request authentication.
  * In-memory token caching with expiry-aware refresh for faster, more reliable requests.

* **Tests**
  * Expanded tests for token fetching, caching, and expired-token scenarios.
  * New integration fixtures and workflows validating expired-token behavior.

* **Chores**
  * Persisted test service data via named volume, improved test orchestration script, added runtime dependency, and updated ignore rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->