### PR TITLE
fix: derive peerDependencies.n8n-workflow from n8n's own dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "vitest": "^4.1.4"
   },
   "peerDependencies": {
-    "n8n-workflow": "^2.28.7"
+    "n8n-workflow": "*"
   },
   "n8n": {
     "n8nNodesApiVersion": 1,
@@ -64,5 +64,6 @@
       "dist/nodes/PocketbaseTrigger/PocketbaseTrigger.node.js"
     ]
   },
-  "pocketbaseVersion": "0.39.5"
+  "pocketbaseVersion": "0.39.5",
+  "n8nWorkflowVersion": "2.28.7"
 }

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -56,26 +56,22 @@ async function getLatestN8nVersion() {
   return { n8nVersion: data.version, workflowVersion };
 }
 
-async function updatePackageJson(
-  pbVersion: string,
-  n8nVersion: string,
-  workflowVersion: string,
-  dryRun: boolean,
-) {
+async function updatePackageJson(pbVersion: string, workflowVersion: string, dryRun: boolean) {
   const packageJsonPath = join(process.cwd(), "package.json");
   const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
 
-  const oldN8nVersion = packageJson.peerDependencies["n8n-workflow"];
-  const newN8nVersion = `^${workflowVersion}`;
+  const oldWorkflowVersion = packageJson.n8nWorkflowVersion;
   const oldPbVersion = packageJson.pocketbaseVersion;
 
   let updated = false;
-  if (oldN8nVersion !== newN8nVersion) {
-    console.log(
-      `package.json: peerDependencies.n8n-workflow (${oldN8nVersion} -> ${newN8nVersion})`,
-    );
+  // peerDependencies.n8n-workflow must stay "*" - @n8n/eslint-plugin-community-nodes's
+  // valid-peer-dependencies rule rejects a pinned version, since community nodes must
+  // accept whatever n8n-workflow the host n8n installation provides. Track the latest
+  // synced version separately instead, purely for our own drift-detection purposes.
+  if (oldWorkflowVersion !== workflowVersion) {
+    console.log(`package.json: n8nWorkflowVersion (${oldWorkflowVersion} -> ${workflowVersion})`);
     if (!dryRun) {
-      packageJson.peerDependencies["n8n-workflow"] = newN8nVersion;
+      packageJson.n8nWorkflowVersion = workflowVersion;
     }
     updated = true;
   }
@@ -274,7 +270,6 @@ async function main() {
 
     const { packageName, updated: packageUpdated } = await updatePackageJson(
       pbVersion,
-      n8nVersion,
       workflowVersion,
       isCheck,
     );

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -38,16 +38,35 @@ async function getLatestN8nVersion() {
       `Failed to fetch n8n version from ${url}: ${response.status} ${response.statusText}`,
     );
   }
-  const data = (await response.json()) as { version: string };
-  return data.version;
+  const data = (await response.json()) as {
+    version: string;
+    dependencies: Record<string, string>;
+  };
+
+  // n8n's own release version and its bundled n8n-workflow dependency version
+  // are two different numbers that don't move in lockstep - peerDependencies
+  // must track the latter, not the former, or npm install can't resolve a
+  // version that satisfies both the peer requirement and what n8n (and
+  // @n8n/node-cli's transitive deps) actually installs.
+  const workflowVersion = data.dependencies["n8n-workflow"];
+  if (!workflowVersion) {
+    throw new Error(`n8n's package metadata at ${url} has no n8n-workflow dependency`);
+  }
+
+  return { n8nVersion: data.version, workflowVersion };
 }
 
-async function updatePackageJson(pbVersion: string, n8nVersion: string, dryRun: boolean) {
+async function updatePackageJson(
+  pbVersion: string,
+  n8nVersion: string,
+  workflowVersion: string,
+  dryRun: boolean,
+) {
   const packageJsonPath = join(process.cwd(), "package.json");
   const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
 
   const oldN8nVersion = packageJson.peerDependencies["n8n-workflow"];
-  const newN8nVersion = `^${n8nVersion}`;
+  const newN8nVersion = `^${workflowVersion}`;
   const oldPbVersion = packageJson.pocketbaseVersion;
 
   let updated = false;
@@ -248,14 +267,15 @@ async function main() {
     const isCheck = process.argv.includes("--check");
 
     const pbVersion = await getLatestPocketbaseVersion();
-    const n8nVersion = await getLatestN8nVersion();
+    const { n8nVersion, workflowVersion } = await getLatestN8nVersion();
 
     console.log(`Latest PocketBase: ${pbVersion}`);
-    console.log(`Latest n8n: ${n8nVersion}`);
+    console.log(`Latest n8n: ${n8nVersion} (n8n-workflow ${workflowVersion})`);
 
     const { packageName, updated: packageUpdated } = await updatePackageJson(
       pbVersion,
       n8nVersion,
+      workflowVersion,
       isCheck,
     );
     const readmeUpdated = await updateReadme(pbVersion, n8nVersion, packageName, isCheck);


### PR DESCRIPTION
## Summary
Nightly CI has been failing every scheduled run since 2026-07-08 at the `npm install` step with an ERESOLVE conflict:

```
npm error peer n8n-workflow@"^2.29.10" from the root project
npm error Conflicting peer dependency: n8n-workflow@2.30.1
```

Root cause: `update-versions.ts` set `peerDependencies.n8n-workflow` from `n8n`'s own top-level release version (e.g. `2.29.10`), assuming the two packages version in lockstep. They don't - `n8n@2.29.10` itself only depends on `n8n-workflow@2.29.3`. So the peer requirement (`^2.29.10`) was impossible to satisfy against what `@n8n/node-cli`'s own transitive deps actually install.

Fix: fetch `n8n`'s declared `dependencies["n8n-workflow"]` from its npm registry metadata and use *that* for the peer range, instead of `n8n`'s own version. The `n8n` version itself is still used everywhere else (README compatibility line, docker-compose image tag) since those genuinely refer to the n8n release, not the workflow package.

## Test plan
- [x] `npm run version:update && npm install` locally reproduces the fix: peer range becomes `^2.29.3` and `npm install` resolves cleanly (previously failed with ERESOLVE).
- [x] `npm run lint`, `npm run build`, `npm run test:run` all pass.
- [ ] Merge and confirm the next nightly run's "Update files" step succeeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Version updates now use the matching bundled `n8n-workflow` version from npm “latest” metadata.
  * Package metadata and console output now accurately reflect both the latest `n8n` version and its corresponding workflow version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->