### PR TITLE
feat: add Delete operation to Pocketbase HTTP node

### DIFF
--- a/nodes/PocketbaseHttp/PocketbaseHttp.node.ts
+++ b/nodes/PocketbaseHttp/PocketbaseHttp.node.ts
@@ -71,6 +71,20 @@ export class PocketbaseHttp implements INodeType {
             },
           },
           {
+            name: "Delete",
+            value: "delete",
+            action: "Delete an element in your collection",
+            routing: {
+              request: {
+                method: "DELETE",
+                url: `=/api/collections/{{$parameter["resource"]}}/records/{{$parameter["elementId"]}}`,
+              },
+              send: {
+                preSend: [authenticatePreSend],
+              },
+            },
+          },
+          {
             name: "List/Search",
             value: "search",
             action: "List or search your collection",
@@ -135,7 +149,7 @@ export class PocketbaseHttp implements INodeType {
         default: "",
         displayOptions: {
           show: {
-            operation: ["view", "update"],
+            operation: ["view", "update", "delete"],
           },
         },
       },

--- a/scripts/full-test.sh
+++ b/scripts/full-test.sh
@@ -131,6 +131,11 @@ if ! echo "$PB_LOGS" | grep -iq "UPDATE .*users.*Updated User"; then
   VERIFIED=false
 fi
 
+if ! echo "$PB_LOGS" | grep -qE "DELETE /api/collections/users/records/"; then
+  echo "❌ Verification failed: 'DELETE /api/collections/users/records/' (user delete) not found in logs."
+  VERIFIED=false
+fi
+
 if [ "$VERIFIED" = "true" ]; then
   echo "✅ Verification successful: Specific CRUD patterns and data found in PocketBase logs!"
 else

--- a/tests/workflows/integration_test.json
+++ b/tests/workflows/integration_test.json
@@ -105,6 +105,23 @@
           "id": "pocketbase-cred-id"
         }
       }
+    },
+    {
+      "parameters": {
+        "resource": "users",
+        "operation": "delete",
+        "elementId": "={{$node[\"Pocketbase Update\"].json[\"id\"]}}"
+      },
+      "id": "6",
+      "name": "Pocketbase Delete",
+      "type": "n8n-nodes-pocketbase.pocketbaseHttp",
+      "typeVersion": 1,
+      "position": [1100, 100],
+      "credentials": {
+        "pocketbaseHttpApi": {
+          "id": "pocketbase-cred-id"
+        }
+      }
     }
   ],
   "connections": {
@@ -153,6 +170,17 @@
       ]
     },
     "Pocketbase List": {
+      "main": [
+        [
+          {
+            "node": "Pocketbase Delete",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pocketbase Delete": {
       "main": [[]]
     }
   }

--- a/tests/workflows/integration_test.json
+++ b/tests/workflows/integration_test.json
@@ -93,7 +93,10 @@
     {
       "parameters": {
         "resource": "users",
-        "operation": "search"
+        "operation": "search",
+        "parameters": {
+          "filter": "=id = '{{$node[\"Pocketbase Update\"].json[\"id\"]}}'"
+        }
       },
       "id": "5",
       "name": "Pocketbase List",


### PR DESCRIPTION
Adds a Delete operation to the Pocketbase HTTP node (DELETE /api/collections/{resource}/records/{elementId}), reusing the existing record picker and auth flow. Covered by the Docker-based integration pipeline.

Fixes #198

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Delete operation for removing records from selected PocketBase collections.
  * Added element selection support for the Delete operation.

* **Bug Fixes**
  * Improved integration verification to confirm deletion requests are recorded in PocketBase logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->