### PR TITLE
test: add broad error-path coverage

### DIFF
--- a/scripts/full-test.sh
+++ b/scripts/full-test.sh
@@ -48,6 +48,13 @@ echo "Package name: $PACKAGE_NAME"
 echo "Building nodes..."
 npm run build
 
+# Ensure a clean slate: if a previous run was killed before its exit trap
+# could tear down volumes, stale PocketBase/n8n data (e.g. leftover workflow
+# IDs, or the duptest@example.com record the duplicate-email test relies on
+# being absent) could cause spurious failures in this run.
+echo "Ensuring a clean Docker Compose state..."
+docker compose -f docker-compose.test.yml down -v --remove-orphans 2>/dev/null || true
+
 # Spin up services
 docker compose -f docker-compose.test.yml up -d
 

--- a/scripts/full-test.sh
+++ b/scripts/full-test.sh
@@ -7,6 +7,8 @@ if command -v fnm &>/dev/null; then
 fi
 
 # EXIT trap for teardown
+ISOLATED_OUTPUT_FILES="expired_token_output.txt notfound_error_output.txt validation_error_output.txt duplicate_error_output.txt"
+
 on_exit() {
 	EXIT_CODE=$?
 	if [ $EXIT_CODE -ne 0 ]; then
@@ -16,18 +18,20 @@ on_exit() {
 			cat workflow_output.txt
 			echo "--------------------------------"
 		fi
-		if [ -f expired_token_output.txt ]; then
-			echo "--- Expired Token Test Output ---"
-			cat expired_token_output.txt
-			echo "--------------------------------"
-		fi
+		for f in $ISOLATED_OUTPUT_FILES; do
+			if [ -f "$f" ]; then
+				echo "--- $f ---"
+				cat "$f"
+				echo "--------------------------------"
+			fi
+		done
 		echo "--- PocketBase Logs ---"
 		docker compose -f docker-compose.test.yml logs pocketbase
 		echo "-----------------------"
 	fi
 	echo "Cleaning up..."
 	docker compose -f docker-compose.test.yml down -v
-	rm -f workflow_output.txt expired_token_output.txt
+	rm -f workflow_output.txt $ISOLATED_OUTPUT_FILES
 	exit $EXIT_CODE
 }
 trap on_exit EXIT
@@ -102,6 +106,9 @@ docker compose -f docker-compose.test.yml run --rm \
     n8n import:credentials --input=/home/node/custom-nodes/tests/workflows/integration_credentials_expired.json && \
     n8n import:workflow --input=/home/node/custom-nodes/tests/workflows/integration_test.json && \
     n8n import:workflow --input=/home/node/custom-nodes/tests/workflows/integration_expired_token_test.json && \
+    n8n import:workflow --input=/home/node/custom-nodes/tests/workflows/integration_error_notfound_test.json && \
+    n8n import:workflow --input=/home/node/custom-nodes/tests/workflows/integration_error_validation_test.json && \
+    n8n import:workflow --input=/home/node/custom-nodes/tests/workflows/integration_error_duplicate_test.json && \
     n8n execute --id=1
 " > workflow_output.txt 2>&1
 
@@ -144,33 +151,71 @@ else
   exit 1
 fi
 
-# Process 2: completely fresh n8n process — no shared memory, DB persisted via volume.
-# This simulates a scheduled execution that starts cold with an expired stored token.
-echo ""
-echo "--- Expired Token Refresh Test (process 2, isolated) ---"
-set +e
-docker compose -f docker-compose.test.yml run --rm \
-  --entrypoint /bin/sh n8n -c "
-    mkdir -p /home/node/.n8n/nodes/node_modules && \
-    rm -f \"/home/node/.n8n/nodes/node_modules/$PACKAGE_NAME\" && \
-    ln -sf /home/node/custom-nodes \"/home/node/.n8n/nodes/node_modules/$PACKAGE_NAME\" && \
-    n8n execute --id=2
-" > expired_token_output.txt 2>&1
-EXPIRED_EXIT=$?
-set -e
+# Process 2+: each runs in a completely fresh n8n process — no shared memory,
+# DB persisted via volume. This simulates a cold-started scheduled execution
+# and is also how we isolate error-path workflows from the main CRUD chain
+# (n8n aborts a workflow on the first node error, so a failing node can't
+# share a workflow with the happy-path assertions above).
+run_isolated_workflow() {
+  local id=$1
+  local output_file=$2
+  set +e
+  docker compose -f docker-compose.test.yml run --rm \
+    --entrypoint /bin/sh n8n -c "
+      mkdir -p /home/node/.n8n/nodes/node_modules && \
+      rm -f \"/home/node/.n8n/nodes/node_modules/$PACKAGE_NAME\" && \
+      ln -sf /home/node/custom-nodes \"/home/node/.n8n/nodes/node_modules/$PACKAGE_NAME\" && \
+      n8n execute --id=$id
+  " > "$output_file" 2>&1
+  local exit_code=$?
+  set -e
+  return $exit_code
+}
 
-if [ $EXPIRED_EXIT -eq 0 ] && grep -q '"status": *"success"' expired_token_output.txt 2>/dev/null; then
-  echo "✅ Workflow with expired token SUCCEEDED in isolated process"
-  echo "   Token was refreshed via preSend without any shared in-memory state"
-else
-  echo "❌ Workflow with expired token FAILED in isolated process"
+expect_isolated_success() {
+  local id=$1 label=$2 output_file=$3
   echo ""
-  echo "   n8n output (last 20 lines, excluding sourcemap noise):"
-  grep -v "Sourcemap" expired_token_output.txt | tail -20 | sed 's/^/   /'
+  echo "--- $label (isolated) ---"
+  local exit_code=0
+  run_isolated_workflow "$id" "$output_file" || exit_code=$?
+  if [ $exit_code -eq 0 ] && grep -q '"status": *"success"' "$output_file" 2>/dev/null; then
+    echo "✅ $label SUCCEEDED as expected"
+  else
+    echo "❌ $label did not succeed as expected (exit $exit_code)"
+    echo "   n8n output (last 20 lines, excluding sourcemap noise):"
+    grep -v "Sourcemap" "$output_file" | tail -20 | sed 's/^/   /'
+    echo "--------------------------------------------------------"
+    exit 1
+  fi
   echo "--------------------------------------------------------"
-  exit 1
-fi
-echo "--------------------------------------------------------"
+}
+
+expect_isolated_failure() {
+  local id=$1 label=$2 output_file=$3 expected_substring=$4
+  echo ""
+  echo "--- $label (isolated) ---"
+  local exit_code=0
+  run_isolated_workflow "$id" "$output_file" || exit_code=$?
+  if [ $exit_code -ne 0 ] && grep -qi "$expected_substring" "$output_file" 2>/dev/null; then
+    echo "✅ $label FAILED as expected (exit $exit_code), matched: \"$expected_substring\""
+  else
+    echo "❌ $label did not fail as expected (exit $exit_code); expected output to contain: \"$expected_substring\""
+    echo "   n8n output (last 20 lines, excluding sourcemap noise):"
+    grep -v "Sourcemap" "$output_file" | tail -20 | sed 's/^/   /'
+    echo "--------------------------------------------------------"
+    exit 1
+  fi
+  echo "--------------------------------------------------------"
+}
+
+# This simulates a scheduled execution that starts cold with an expired stored token;
+# a successful run proves the token was refreshed via preSend without any shared
+# in-memory state.
+expect_isolated_success 2 "Expired Token Refresh Test" expired_token_output.txt
+
+expect_isolated_failure 3 "Not Found Error Test" notfound_error_output.txt "wasn't found"
+expect_isolated_failure 4 "Validation Error Test" validation_error_output.txt "Values don't match"
+expect_isolated_failure 5 "Duplicate Field Error Test" duplicate_error_output.txt "Value must be unique"
 
 # Run unit and integration tests
 export RUN_POCKETBASE_INTEGRATION="true"

--- a/tests/GenericFunctions.spec.ts
+++ b/tests/GenericFunctions.spec.ts
@@ -207,5 +207,108 @@ describe("GenericFunctions", () => {
       await pagination.call(mockThis as unknown as IExecutePaginationFunctions, requestOptions);
       expect(mockThis.makeRoutingRequest).toHaveBeenCalled();
     });
+
+    it("should throw error if response body is not an object", async () => {
+      mockThis.getNodeParameter.mockImplementation((name: string, defaultValue: unknown) => {
+        if (name === "parameters.allElements") return false;
+        if (name === "parameters.page") return 1;
+        return defaultValue;
+      });
+
+      mockThis.makeRoutingRequest.mockResolvedValueOnce([{ json: null }]);
+
+      const requestOptions: DeclarativeRestApiSettings.ResultOptions = {
+        options: { qs: {} },
+        preSend: [],
+        postReceive: [],
+      };
+      await expect(
+        pagination.call(mockThis as unknown as IExecutePaginationFunctions, requestOptions),
+      ).rejects.toThrow("Invalid response from PocketBase");
+    });
+
+    it("should throw error if page is missing from the first response", async () => {
+      mockThis.getNodeParameter.mockImplementation((name: string, defaultValue: unknown) => {
+        if (name === "parameters.allElements") return false;
+        if (name === "parameters.page") return 1;
+        return defaultValue;
+      });
+
+      mockThis.makeRoutingRequest.mockResolvedValueOnce([
+        { json: { totalPages: 1, items: [] } },
+      ]);
+
+      const requestOptions: DeclarativeRestApiSettings.ResultOptions = {
+        options: { qs: {} },
+        preSend: [],
+        postReceive: [],
+      };
+      await expect(
+        pagination.call(mockThis as unknown as IExecutePaginationFunctions, requestOptions),
+      ).rejects.toThrow("Missing or invalid page in PocketBase response");
+    });
+
+    it("should throw error if returned page does not match requested page", async () => {
+      mockThis.getNodeParameter.mockImplementation((name: string, defaultValue: unknown) => {
+        if (name === "parameters.allElements") return false;
+        if (name === "parameters.page") return 1;
+        return defaultValue;
+      });
+
+      mockThis.makeRoutingRequest.mockResolvedValueOnce([
+        { json: { page: 2, totalPages: 2, items: [] } },
+      ]);
+
+      const requestOptions: DeclarativeRestApiSettings.ResultOptions = {
+        options: { qs: {} },
+        preSend: [],
+        postReceive: [],
+      };
+      await expect(
+        pagination.call(mockThis as unknown as IExecutePaginationFunctions, requestOptions),
+      ).rejects.toThrow("PocketBase returned page 2 but we requested 1");
+    });
+
+    it("should throw error if totalPages is missing while fetching all elements", async () => {
+      mockThis.getNodeParameter.mockImplementation((name: string, defaultValue: unknown) => {
+        if (name === "parameters.allElements") return true;
+        if (name === "parameters.page") return 1;
+        return defaultValue;
+      });
+
+      mockThis.makeRoutingRequest.mockResolvedValueOnce([{ json: { page: 1, items: [] } }]);
+
+      const requestOptions: DeclarativeRestApiSettings.ResultOptions = {
+        options: { qs: {} },
+        preSend: [],
+        postReceive: [],
+      };
+      await expect(
+        pagination.call(mockThis as unknown as IExecutePaginationFunctions, requestOptions),
+      ).rejects.toThrow("Missing or invalid totalPages in PocketBase response");
+    });
+
+    it("should throw error if items is not an array", async () => {
+      mockThis.getNodeParameter.mockImplementation((name: string, defaultValue: unknown) => {
+        if (name === "parameters.allElements") return false;
+        if (name === "parameters.page") return 1;
+        return defaultValue;
+      });
+
+      mockThis.makeRoutingRequest.mockResolvedValueOnce([
+        { json: { page: 1, items: "not-an-array" } },
+      ]);
+
+      const requestOptions: DeclarativeRestApiSettings.ResultOptions = {
+        options: { qs: {} },
+        preSend: [],
+        postReceive: [],
+      };
+      await expect(
+        pagination.call(mockThis as unknown as IExecutePaginationFunctions, requestOptions),
+      ).rejects.toThrow(
+        "PocketBase response for page 1 (of 1) did not contain an items array",
+      );
+    });
   });
 });

--- a/tests/RequestBodyFunctions.spec.ts
+++ b/tests/RequestBodyFunctions.spec.ts
@@ -87,6 +87,84 @@ describe("RequestBodyFunctions", () => {
       });
     });
 
+    it("should throw error if bodyJson is neither a string nor an object", async () => {
+      const mockThis = {
+        getNode: vi.fn(() => ({ name: "Pocketbase", type: "test.pocketbase" })),
+        getNodeParameter: vi.fn().mockImplementation((name) => {
+          if (name === "bodyType") return ["bodyJson"];
+          if (name === "bodyJson") return 123;
+          return undefined;
+        }),
+      } as unknown as IExecuteSingleFunctions;
+
+      const requestOptions: IHttpRequestOptions = { url: "http://test.com", method: "POST" };
+      await expect(prepareRequestBody.call(mockThis, requestOptions)).rejects.toMatchObject({
+        message: expect.stringContaining("JSON Body must be a JSON object or string"),
+        constructor: NodeOperationError,
+      });
+    });
+
+    describe("binaryData errors", () => {
+      it("should throw a plain Error if no binaryPropertyName is provided", async () => {
+        const mockThis = {
+          getNode: vi.fn(() => ({ name: "Pocketbase", type: "test.pocketbase" })),
+          getNodeParameter: vi.fn().mockImplementation((name, defaultValue) => {
+            if (name === "bodyType") return ["binaryData"];
+            if (name === "binaryPropertyName") return "";
+            return defaultValue;
+          }),
+          logger: {
+            info: vi.fn(),
+            debug: vi.fn(),
+          },
+          helpers: {
+            assertBinaryData: vi.fn(),
+            getBinaryDataBuffer: vi.fn(),
+          },
+        } as unknown as IExecuteSingleFunctions;
+
+        const requestOptions: IHttpRequestOptions = { url: "http://test.com", method: "POST" };
+        let thrown: unknown;
+        try {
+          await prepareRequestBody.call(mockThis, requestOptions);
+        } catch (error) {
+          thrown = error;
+        }
+
+        expect(thrown).toBeInstanceOf(Error);
+        expect(thrown).not.toBeInstanceOf(NodeOperationError);
+        expect((thrown as Error).message).toContain(
+          "Binary data selected but no property name provided",
+        );
+      });
+
+      it("should propagate the error thrown by assertBinaryData when the binary property is missing", async () => {
+        const mockThis = {
+          getNode: vi.fn(() => ({ name: "Pocketbase", type: "test.pocketbase" })),
+          getNodeParameter: vi.fn().mockImplementation((name, defaultValue) => {
+            if (name === "bodyType") return ["binaryData"];
+            if (name === "binaryPropertyName") return "data";
+            return defaultValue;
+          }),
+          logger: {
+            info: vi.fn(),
+            debug: vi.fn(),
+          },
+          helpers: {
+            assertBinaryData: vi.fn(() => {
+              throw new Error("No binary data property 'data' exists on item.");
+            }),
+            getBinaryDataBuffer: vi.fn(),
+          },
+        } as unknown as IExecuteSingleFunctions;
+
+        const requestOptions: IHttpRequestOptions = { url: "http://test.com", method: "POST" };
+        await expect(prepareRequestBody.call(mockThis, requestOptions)).rejects.toThrow(
+          "No binary data property 'data' exists on item.",
+        );
+      });
+    });
+
     it("should parse and append bodyJson correctly in Multipart mode, converting null to 'null' string and removing stale Content-Type", async () => {
       const appendSpy = vi.spyOn(FormData.prototype, "append");
       const mockThis = {

--- a/tests/workflows/integration_error_duplicate_test.json
+++ b/tests/workflows/integration_error_duplicate_test.json
@@ -1,0 +1,112 @@
+{
+  "id": "5",
+  "name": "Pocketbase Duplicate Field Error Test Workflow",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "1",
+      "name": "When clicking 'Test workflow'",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [100, 100]
+    },
+    {
+      "parameters": {
+        "resource": "users",
+        "operation": "create",
+        "bodyType": ["fields"],
+        "fields": {
+          "assignments": [
+            {
+              "name": "username",
+              "value": "duptestuser"
+            },
+            {
+              "name": "email",
+              "value": "duptest@example.com"
+            },
+            {
+              "name": "password",
+              "value": "password123"
+            },
+            {
+              "name": "passwordConfirm",
+              "value": "password123"
+            }
+          ]
+        }
+      },
+      "id": "2",
+      "name": "Pocketbase Create First User",
+      "type": "n8n-nodes-pocketbase.pocketbaseHttp",
+      "typeVersion": 1,
+      "position": [300, 100],
+      "credentials": {
+        "pocketbaseHttpApi": {
+          "id": "pocketbase-cred-id"
+        }
+      }
+    },
+    {
+      "parameters": {
+        "resource": "users",
+        "operation": "create",
+        "bodyType": ["fields"],
+        "fields": {
+          "assignments": [
+            {
+              "name": "username",
+              "value": "duptestuser2"
+            },
+            {
+              "name": "email",
+              "value": "duptest@example.com"
+            },
+            {
+              "name": "password",
+              "value": "password123"
+            },
+            {
+              "name": "passwordConfirm",
+              "value": "password123"
+            }
+          ]
+        }
+      },
+      "id": "3",
+      "name": "Pocketbase Create Duplicate Email User",
+      "type": "n8n-nodes-pocketbase.pocketbaseHttp",
+      "typeVersion": 1,
+      "position": [500, 100],
+      "credentials": {
+        "pocketbaseHttpApi": {
+          "id": "pocketbase-cred-id"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "When clicking 'Test workflow'": {
+      "main": [
+        [
+          {
+            "node": "Pocketbase Create First User",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Pocketbase Create First User": {
+      "main": [
+        [
+          {
+            "node": "Pocketbase Create Duplicate Email User",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  }
+}

--- a/tests/workflows/integration_error_notfound_test.json
+++ b/tests/workflows/integration_error_notfound_test.json
@@ -1,0 +1,44 @@
+{
+  "id": "3",
+  "name": "Pocketbase Not Found Error Test Workflow",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "1",
+      "name": "When clicking 'Test workflow'",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [100, 100]
+    },
+    {
+      "parameters": {
+        "resource": "users",
+        "operation": "view",
+        "elementId": "nonexistentrecord0001"
+      },
+      "id": "2",
+      "name": "Pocketbase View Nonexistent Record",
+      "type": "n8n-nodes-pocketbase.pocketbaseHttp",
+      "typeVersion": 1,
+      "position": [300, 100],
+      "credentials": {
+        "pocketbaseHttpApi": {
+          "id": "pocketbase-cred-id"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "When clicking 'Test workflow'": {
+      "main": [
+        [
+          {
+            "node": "Pocketbase View Nonexistent Record",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  }
+}

--- a/tests/workflows/integration_error_validation_test.json
+++ b/tests/workflows/integration_error_validation_test.json
@@ -1,0 +1,64 @@
+{
+  "id": "4",
+  "name": "Pocketbase Validation Error Test Workflow",
+  "nodes": [
+    {
+      "parameters": {},
+      "id": "1",
+      "name": "When clicking 'Test workflow'",
+      "type": "n8n-nodes-base.manualTrigger",
+      "typeVersion": 1,
+      "position": [100, 100]
+    },
+    {
+      "parameters": {
+        "resource": "users",
+        "operation": "create",
+        "bodyType": ["fields"],
+        "fields": {
+          "assignments": [
+            {
+              "name": "username",
+              "value": "=pwmismatch{{$now.toMillis()}}"
+            },
+            {
+              "name": "email",
+              "value": "=pwmismatch{{$now.toMillis()}}@example.com"
+            },
+            {
+              "name": "password",
+              "value": "password123"
+            },
+            {
+              "name": "passwordConfirm",
+              "value": "different456"
+            }
+          ]
+        }
+      },
+      "id": "2",
+      "name": "Pocketbase Create With Mismatched Passwords",
+      "type": "n8n-nodes-pocketbase.pocketbaseHttp",
+      "typeVersion": 1,
+      "position": [300, 100],
+      "credentials": {
+        "pocketbaseHttpApi": {
+          "id": "pocketbase-cred-id"
+        }
+      }
+    }
+  ],
+  "connections": {
+    "When clicking 'Test workflow'": {
+      "main": [
+        [
+          {
+            "node": "Pocketbase Create With Mismatched Passwords",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Unit tests fill the untested throw branches in `pagination()` and `prepareRequestBody()`/`handleBinaryData()`. Integration adds three isolated Docker-pipeline workflows proving a real PocketBase error (404, validation mismatch, uniqueness conflict) actually fails the n8n workflow end-to-end, reusing the existing expired-token isolated-process pattern (now factored into shared helpers in `full-test.sh`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded integration coverage for expired-token, missing-record, validation, and duplicate-field error scenarios.
  * Added pagination tests for malformed or incomplete responses.
  * Added request-body validation tests for invalid JSON and missing binary data.
  * Added workflows covering duplicate users, nonexistent records, and mismatched passwords.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->