### PR TITLE
ci: allow manually triggering a release without a version drift

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,4 +1,4 @@
-name: Nightly Compatibility Check
+name: Nightly Compatibility Check & Release
 
 on:
   push:
@@ -6,6 +6,10 @@ on:
       - main
   schedule:
     - cron: "34 1 * * *"
+  # Manual runs always produce a release, even with no pending compatibility
+  # drift — use this to ship a patch release of whatever is currently on
+  # main (e.g. after merging feature/test PRs) without waiting for the
+  # nightly cron to find an n8n/PocketBase version bump.
   workflow_dispatch:
 
 jobs:
@@ -76,6 +80,19 @@ jobs:
             echo "updates_found=true" >> "$GITHUB_OUTPUT"
           fi
 
+      # Manual runs (workflow_dispatch) always release, regardless of whether
+      # a compatibility drift was found; scheduled/cron runs only release
+      # when version:check above actually found something to update.
+      - name: Determine whether to release
+        id: should_release
+        if: github.event_name != 'push'
+        run: |
+          if [ "${{ steps.check_updates.outputs.updates_found }}" = "true" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "value=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "value=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Update files
         if: steps.check_updates.outputs.updates_found == 'true'
         run: |
@@ -83,11 +100,11 @@ jobs:
           npm install
 
       - name: Run pipeline
-        if: steps.check_updates.outputs.updates_found == 'true'
+        if: steps.should_release.outputs.value == 'true'
         run: npm run test:pipeline
 
       - name: Bump patch version and changelog
-        if: steps.check_updates.outputs.updates_found == 'true'
+        if: steps.should_release.outputs.value == 'true'
         id: bump
         run: |
           npm version patch --no-git-tag-version --allow-same-version > /dev/null
@@ -97,20 +114,20 @@ jobs:
           echo "new_version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Ensure release label exists
-        if: steps.check_updates.outputs.updates_found == 'true'
+        if: steps.should_release.outputs.value == 'true'
         env:
           GH_TOKEN: ${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}
         run: gh label create release --color 0e8a16 --description "Automated release PR" 2>/dev/null || true
 
       - name: Create Pull Request
-        if: steps.check_updates.outputs.updates_found == 'true'
+        if: steps.should_release.outputs.value == 'true'
         id: cpr
         uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}
           commit-message: "Release ${{ steps.bump.outputs.new_version }}"
           title: "Release ${{ steps.bump.outputs.new_version }}"
-          body: "Automated nightly compatibility updates. Merging tags and publishes ${{ steps.bump.outputs.new_version }} to npm."
+          body: "Automated release. Merging tags and publishes ${{ steps.bump.outputs.new_version }} to npm."
           branch: nightly-updates
           base: main
           delete-branch: true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,6 +30,11 @@ jobs:
 
       - uses: actions/checkout@v7
         with:
+          # Pinned so a manual workflow_dispatch run targeted at a non-main
+          # branch (selectable in the dispatch UI/CLI) can't create a
+          # release PR — or publish to npm — from unmerged/experimental
+          # commits. push/schedule events are always already on main.
+          ref: main
           fetch-depth: 0 # Needed for auto-changelog to see full history and tags
           persist-credentials: false
           token: ${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}
@@ -70,14 +75,25 @@ jobs:
           git tag "$VERSION"
           git push "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" "$VERSION"
 
+      # update-versions.ts --check exits 0 (up to date), 1 (confirmed
+      # drift), or 2 (script failure, e.g. a transient GitHub/npm API
+      # error - not evidence of drift). Only exit 1 sets updates_found;
+      # exit 2 fails this step outright rather than being misread as drift.
       - name: Check for updates
         id: check_updates
         if: github.event_name != 'push'
         run: |
-          if npm run version:check; then
+          set +e
+          npm run version:check
+          CHECK_EXIT=$?
+          set -e
+          if [ $CHECK_EXIT -eq 0 ]; then
             echo "updates_found=false" >> "$GITHUB_OUTPUT"
-          else
+          elif [ $CHECK_EXIT -eq 1 ]; then
             echo "updates_found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "version:check failed (exit $CHECK_EXIT) - treating as a script error, not confirmed drift"
+            exit $CHECK_EXIT
           fi
 
       # Manual runs (workflow_dispatch) always release, regardless of whether
@@ -86,8 +102,11 @@ jobs:
       - name: Determine whether to release
         id: should_release
         if: github.event_name != 'push'
+        env:
+          UPDATES_FOUND: ${{ steps.check_updates.outputs.updates_found }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
-          if [ "${{ steps.check_updates.outputs.updates_found }}" = "true" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          if [ "$UPDATES_FOUND" = "true" ] || [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             echo "value=true" >> "$GITHUB_OUTPUT"
           else
             echo "value=false" >> "$GITHUB_OUTPUT"
@@ -127,7 +146,7 @@ jobs:
           token: ${{ steps.generate_token.outputs.token || secrets.GITHUB_TOKEN }}
           commit-message: "Release ${{ steps.bump.outputs.new_version }}"
           title: "Release ${{ steps.bump.outputs.new_version }}"
-          body: "Automated release. Merging tags and publishes ${{ steps.bump.outputs.new_version }} to npm."
+          body: "Automated release. Merging this PR tags the release and publishes ${{ steps.bump.outputs.new_version }} to npm."
           branch: nightly-updates
           base: main
           delete-branch: true

--- a/scripts/update-versions.ts
+++ b/scripts/update-versions.ts
@@ -294,8 +294,12 @@ async function main() {
       console.log("\nEverything is up to date.");
     }
   } catch (error) {
+    // Exit 2 (not 1) so callers can tell a genuine script failure (e.g. a
+    // transient GitHub/npm API error) apart from exit 1's "confirmed
+    // drift found" in --check mode - callers must not treat the two as
+    // the same "there is drift" signal.
     console.error("Error updating versions:", error);
-    process.exit(1);
+    process.exit(2);
   }
 }
 


### PR DESCRIPTION
Manual workflow_dispatch runs of the nightly workflow now always open a release PR (patch bump), instead of only doing so when version:check finds an n8n/PocketBase compatibility drift. Scheduled cron runs keep their original drift-only gating unchanged. Renamed the workflow's display name to reflect the dual purpose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated compatibility checks and release handling for scheduled and manual workflow runs.
  * Manual runs now proceed with releases, while scheduled runs release only when updates are detected.
  * Manual workflow runs now use the main branch for consistent release preparation.
* **Bug Fixes**
  * Improved version-check error handling so genuine script failures are distinguished from detected version differences.
* **Documentation**
  * Updated pull-request guidance to clarify that merging publishes the version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->